### PR TITLE
Add contact refusal flow

### DIFF
--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Entity/CampaignParticipation.php
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Entity/CampaignParticipation.php
@@ -261,6 +261,13 @@ class CampaignParticipation
     private $contactRequested = false;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean", options={"default":false})
+     */
+    private $contactRefused = false;
+
+    /**
      * @var string
      *
      * @ORM\Column(type="string", nullable=true)
@@ -752,6 +759,18 @@ class CampaignParticipation
     public function setContactRequested(bool $contactRequested): self
     {
         $this->contactRequested = $contactRequested;
+
+        return $this;
+    }
+
+    public function isContactRefused(): bool
+    {
+        return $this->contactRefused;
+    }
+
+    public function setContactRefused(bool $contactRefused): self
+    {
+        $this->contactRefused = $contactRefused;
 
         return $this;
     }

--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/config/routing_questionnaire.yml
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/config/routing_questionnaire.yml
@@ -12,6 +12,11 @@ azimut_montgolfiere_questionnaire_contact:
     path:   /contact
     methods: POST
 
+azimut_montgolfiere_questionnaire_refuse_contact:
+    defaults: { _controller: "AzimutMontgolfiereAppBundle:Questionnaire:refuseContact" }
+    path:   /refuse-contact
+    methods: POST
+
 azimut_montgolfiere_questionnaire_theme_image:
     path: /{theme}
     defaults: { _controller: "AzimutMontgolfiereAppBundle:Questionnaire:themeImage" }

--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/views/Questionnaire/congratulations.html.twig
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/views/Questionnaire/congratulations.html.twig
@@ -20,7 +20,7 @@
                         </p>
                         <p>
                             <a href="#" class="btn btn-primary" data-toggle="contact-modal" data-contact-type="low-score" data-contact-finish="changeSection(1, document.querySelector('#scrollable-container'))">{{ 'montgolfiere.questionnaire.results.yes'|trans }}</a>
-                            <a href="#" class="btn btn-primary" data-action="next" data-target="#scrollable-container">{{ 'montgolfiere.questionnaire.results.no'|trans }}</a>
+                            <a href="#" class="btn btn-primary" onclick="refuseContact(); return false;">{{ 'montgolfiere.questionnaire.results.no'|trans }}</a>
                         </p>
                         <p>
                             {{ 'montgolfiere.questionnaire.results.low_score_text3'|trans }}
@@ -111,6 +111,13 @@
             }).always(function() {
                 $(el).removeClass('active').text('{{ 'montgolfiere.questionnaire.results.modals.email.submit'|trans }}');
             });
+        }
+
+        function refuseContact() {
+            $.post('{{ path('azimut_montgolfiere_questionnaire_refuse_contact', {questionnaireToken: campaign.questionnaireToken}) }}')
+                .always(function() {
+                    changeSection(1, document.querySelector('#scrollable-container'));
+                });
         }
     </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove refusal email from `checkParticipationAlert()`
- store a new `contactRefused` flag on `CampaignParticipation`
- add `refuseContactAction` to send the refusal email
- POST to new route when user declines contact
- wire new controller route

## Testing
- `php -l src/Azimut/Bundle/MontgolfiereAppBundle/Controller/QuestionnaireController.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fafc3e80c83238b810de03d36f209