### PR TITLE
Add RPS alert tracking

### DIFF
--- a/app/DoctrineMigrations/Version20230710000000.php
+++ b/app/DoctrineMigrations/Version20230710000000.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20230710000000 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE montgolfiere_campaign_participation ADD rpsAlert TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE montgolfiere_campaign_participation DROP rpsAlert');
+    }
+}

--- a/app/Resources/views/PageLayout/ixa/consultantarea_campaign.html.twig
+++ b/app/Resources/views/PageLayout/ixa/consultantarea_campaign.html.twig
@@ -12,6 +12,9 @@
                 </div>
                 <br>
             {% endif %}
+            {% if is_granted('ROLE_FRONT_CONSULTANT_ADVANCED') and rpsAlertCount > 0 %}
+                <div class="alert alert-danger">{{ 'montgolfiere.consultantarea.rps_alert_count'|trans({'%count%': rpsAlertCount}) }}</div>
+            {% endif %}
 
             {% for sortingFactor in campaign.sortingFactors %}
                 {% if sortingFactor.values|length>1 %}

--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Controller/ConsultantAreaController.php
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Controller/ConsultantAreaController.php
@@ -108,6 +108,8 @@ class ConsultantAreaController extends AbstractController
             return $this->redirectToRoute('azimut_frontoffice', ['path' => 'espace-consultant',]);
         }
 
+        $rpsAlertCount = $this->countRpsAlerts($campaign);
+
         return $this->render(':PageLayout/ixa:consultantarea_campaign.html.twig', [
             'site' => $site,
             'page' => $page,
@@ -116,6 +118,7 @@ class ConsultantAreaController extends AbstractController
             'pageDescription' => $page->getMetaDescription(),
             'pagePath' => $pagePath,
             'campaign' => $campaign,
+            'rpsAlertCount' => $rpsAlertCount,
         ]);
     }
 
@@ -335,6 +338,19 @@ class ConsultantAreaController extends AbstractController
         $this->participationFilterHelper->handleFilterForm($form, $qb, $campaign);
 
         return $qb->getQuery()->getResult();
+    }
+
+    private function countRpsAlerts(Campaign $campaign): int
+    {
+        $repo = $this->getDoctrine()->getRepository(CampaignParticipation::class);
+
+        return (int)$repo->createQueryBuilder('cp')
+            ->select('COUNT(cp.id)')
+            ->where('cp.campaign = :campaign')
+            ->andWhere('cp.rpsAlert = true')
+            ->setParameter('campaign', $campaign)
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     public function generateWordDocumentAction(Campaign $campaign, Request $request)

--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Controller/ConsultantAreaController.php
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Controller/ConsultantAreaController.php
@@ -346,7 +346,8 @@ class ConsultantAreaController extends AbstractController
 
         return (int)$repo->createQueryBuilder('cp')
             ->select('COUNT(cp.id)')
-            ->where('cp.campaign = :campaign')
+            ->leftJoin('cp.segment', 's')
+            ->where('s.campaign = :campaign')
             ->andWhere('cp.rpsAlert = true')
             ->setParameter('campaign', $campaign)
             ->getQuery()

--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Controller/QuestionnaireController.php
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Controller/QuestionnaireController.php
@@ -404,6 +404,7 @@ class QuestionnaireController extends AbstractController
 
         $this->mailer->send($message);
         $participation->setWBEAlertSent(true);
+        $participation->setRpsAlert(true);
 
 
         $this->getDoctrine()->getManager()->flush();

--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Entity/CampaignParticipation.php
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Entity/CampaignParticipation.php
@@ -258,6 +258,13 @@ class CampaignParticipation
      *
      * @ORM\Column(type="boolean", options={"default":false})
      */
+    private $rpsAlert = false;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean", options={"default":false})
+     */
     private $contactRequested = false;
 
     /**
@@ -747,6 +754,18 @@ class CampaignParticipation
     public function setWBEAlertSent(bool $WBEAlertSent): self
     {
         $this->WBEAlertSent = $WBEAlertSent;
+
+        return $this;
+    }
+
+    public function isRpsAlert(): bool
+    {
+        return $this->rpsAlert;
+    }
+
+    public function setRpsAlert(bool $rpsAlert): self
+    {
+        $this->rpsAlert = $rpsAlert;
 
         return $this;
     }

--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/translations/messages.en.yml
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/translations/messages.en.yml
@@ -412,3 +412,9 @@ montgolfiere:
         footer:
             text1: "Questions? Suggestions?"
             text2: "Glad to hear you"
+    backoffice:
+        campaigns:
+            participations:
+                rps_alert_flag: "RPS alert"
+    consultantarea:
+        rps_alert_count: "%count% RPS alert(s)"

--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/translations/messages.fr.yml
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/translations/messages.fr.yml
@@ -308,6 +308,7 @@ montgolfiere:
                 consult_wbe: "Consulter le profil"
                 block_wbe: "Bloquer le profil"
                 ip_address: "Adresse IP"
+                rps_alert_flag: "Alerte RPS"
                 opinions:
                     title: "Avis des participants"
                     flash:
@@ -1023,3 +1024,5 @@ montgolfiere:
         footer:
             text1: "Des questions ? Des suggestions ?"
             text2 : "Nous serions heureux de les entendre"
+    consultantarea:
+        rps_alert_count: "%count% alerte(s) RPS"

--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/views/Backoffice/Campaigns/participations.html.twig
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/views/Backoffice/Campaigns/participations.html.twig
@@ -58,6 +58,9 @@
                 <td>{{ participation.managerName }}</td>
                 <td>{{ participation.updatedAt|localizeddate }}</td>
                 <td class="icon-column">
+                    {% if participation.rpsAlert %}
+                        <span class="glyphicon glyphicon-warning-sign text-danger" data-toggle="tooltip" title="{{ 'montgolfiere.backoffice.campaigns.participations.rps_alert_flag'|trans }}"></span>
+                    {% endif %}
                     {{ form(deleteForms[participation.id]) }}
                     <a href="{{ path('azimut_montgolfiere_app_backoffice_campaigns_participations_read', {'id': campaign.id, 'participation': participation.id}) }}"><i class="glyphicon glyphicon-pro glyphicon-pro-eye-open"></i></a>
                     <a href="{{ path('azimut_montgolfiere_app_backoffice_campaigns_participations_edit', {'id': campaign.id, 'participation': participation.id}) }}"><i class="glyphicon glyphicon-pro glyphicon-pro-pencil"></i></a>

--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Tests/Entity/CampaignParticipationTest.php
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Tests/Entity/CampaignParticipationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Azimut\Bundle\MontgolfiereAppBundle\Tests\Entity;
+
+use Azimut\Bundle\MontgolfiereAppBundle\Entity\CampaignParticipation;
+use PHPUnit\Framework\TestCase;
+
+class CampaignParticipationTest extends TestCase
+{
+    public function testRpsAlertProperty()
+    {
+        $participation = new CampaignParticipation();
+        $this->assertFalse($participation->isRpsAlert());
+        $participation->setRpsAlert(true);
+        $this->assertTrue($participation->isRpsAlert());
+    }
+}


### PR DESCRIPTION
## Summary
- track RPS alerts on `CampaignParticipation`
- email alert also stores the flag
- show RPS alerts count to advanced consultants
- flag participations with RPS alert in backoffice
- provide translations and a migration
- add a unit test for the new flag

## Testing
- `phpunit -c phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc1ca9ebc83238f0fa9743500a877