### PR TITLE
Allow disabling house legend rendering

### DIFF
--- a/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/views/Backoffice/Campaigns/draw_house.html.twig
+++ b/src/Azimut/Bundle/MontgolfiereAppBundle/Resources/views/Backoffice/Campaigns/draw_house.html.twig
@@ -1,4 +1,5 @@
 {% set showOptions = showOptions|default(false) %}
+{% set showLegend = showLegend|default(true) %}
 {% if campaign is defined and form is defined and participations is defined %}
     {% if data_route is not defined %}
         {% set data_route = 'azimut_montgolfiere_app_backoffice_campaigns_house_data' %}
@@ -31,6 +32,7 @@
             var house = $('#house');
             house.before('<span id="loading">Chargement de l\'image en cours</span>');
             var stage = new createjs.Stage("house");
+            var showLegend = {{ showLegend|json_encode|raw }};
             setTimeout(function() {
                 stage.update();
             }, 10000);
@@ -929,7 +931,9 @@
                 });
             }).then(function(data) {
                 buildLegend(data.analysisVersion);
-                drawLegend(stage, data.analysisVersion);
+                if (showLegend) {
+                    drawLegend(stage, data.analysisVersion);
+                }
                 setColor("restitution-color-square");
                 // Title
                 house.data("title", data.title);


### PR DESCRIPTION
## Summary
- toggle `drawLegend` with a new `showLegend` flag

## Testing
- `npm run build` *(fails: encore not found)*
- `composer install` *(fails: requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_6870d1a00b4c8323b5e73181bd2e7c97